### PR TITLE
Speed up relationship caching

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "contentful/contentful.swift" ~> 5.2.0
+github "contentful/contentful.swift" ~> 5.3.0
 

--- a/ContentfulPersistence.xcodeproj/project.pbxproj
+++ b/ContentfulPersistence.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02E58FA12535C9E30039F3A5 /* RelationshipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E58FA02535C9E30039F3A5 /* RelationshipData.swift */; };
+		02E58FA22535C9E30039F3A5 /* RelationshipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E58FA02535C9E30039F3A5 /* RelationshipData.swift */; };
+		02E58FA32535C9E30039F3A5 /* RelationshipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E58FA02535C9E30039F3A5 /* RelationshipData.swift */; };
+		02E58FA42535C9E30039F3A5 /* RelationshipData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E58FA02535C9E30039F3A5 /* RelationshipData.swift */; };
 		5D001E5C2004019C00AC5A4C /* symbols-array.json in Resources */ = {isa = PBXBuildFile; fileRef = 5D001E5A2004019700AC5A4C /* symbols-array.json */; };
 		5D001E5D2004019D00AC5A4C /* symbols-array.json in Resources */ = {isa = PBXBuildFile; fileRef = 5D001E5A2004019700AC5A4C /* symbols-array.json */; };
 		5D001E5E2004019D00AC5A4C /* symbols-array.json in Resources */ = {isa = PBXBuildFile; fileRef = 5D001E5A2004019700AC5A4C /* symbols-array.json */; };
@@ -297,6 +301,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02E58FA02535C9E30039F3A5 /* RelationshipData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipData.swift; sourceTree = "<group>"; };
 		5D001E5A2004019700AC5A4C /* symbols-array.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "symbols-array.json"; sourceTree = "<group>"; };
 		5D26507321933E320072FAEE /* Contentful.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Contentful.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D265075219343DB0072FAEE /* Contentful.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Contentful.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -332,7 +337,7 @@
 		6FD0311822CE3A7800790FDB /* multi-page-non-optional-link-resolution2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "multi-page-non-optional-link-resolution2.json"; sourceTree = "<group>"; };
 		A1A9FBE31CABE8EA00430734 /* ContentfulPersistence.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ContentfulPersistence.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A9FBED1CABE8EA00430734 /* ContentfulPersistenceTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ContentfulPersistenceTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		ED10E8841E48AB840061741F /* SynchronizationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SynchronizationManager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		ED10E8841E48AB840061741F /* SynchronizationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SynchronizationManager.swift; sourceTree = "<group>"; };
 		ED10E8851E48AB840061741F /* CoreDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataStore.swift; sourceTree = "<group>"; };
 		ED10E8861E48AB840061741F /* DataCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCache.swift; sourceTree = "<group>"; };
 		ED10E8921E48AC720061741F /* Asset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Asset.swift; sourceTree = "<group>"; };
@@ -482,6 +487,7 @@
 				6D5CEDB724FC2493005E8B41 /* Relationship.swift */,
 				6D5CEDB624FC2493005E8B41 /* RelationshipCache.swift */,
 				6D87843624FCEBC7003E69CD /* RelationshipChildId.swift */,
+				02E58FA02535C9E30039F3A5 /* RelationshipData.swift */,
 				6D5CEDC924FC24B1005E8B41 /* RelationshipsManager.swift */,
 				6D5CEDB524FC2493005E8B41 /* ToManyRelationship.swift */,
 				6D5CEDB824FC2493005E8B41 /* ToOneRelationship.swift */,
@@ -1192,6 +1198,7 @@
 				ED10E88B1E48AB840061741F /* SynchronizationManager.swift in Sources */,
 				ED9C21F51EF2C4FB00882ABF /* Persistable.swift in Sources */,
 				ED10E88D1E48AB840061741F /* DataCache.swift in Sources */,
+				02E58FA12535C9E30039F3A5 /* RelationshipData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1257,6 +1264,7 @@
 				ED10E8D61E48BF1D0061741F /* SynchronizationManager.swift in Sources */,
 				ED9C21F61EF2C4FB00882ABF /* Persistable.swift in Sources */,
 				ED10E8D81E48BF1D0061741F /* DataCache.swift in Sources */,
+				02E58FA22535C9E30039F3A5 /* RelationshipData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1276,6 +1284,7 @@
 				ED10E9011E48CD1E0061741F /* SynchronizationManager.swift in Sources */,
 				ED9C21F71EF2C4FB00882ABF /* Persistable.swift in Sources */,
 				ED10E9031E48CD1E0061741F /* DataCache.swift in Sources */,
+				02E58FA32535C9E30039F3A5 /* RelationshipData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1295,6 +1304,7 @@
 				ED10E9071E48CD1F0061741F /* SynchronizationManager.swift in Sources */,
 				ED9C21F81EF2C4FB00882ABF /* Persistable.swift in Sources */,
 				ED10E9091E48CD1F0061741F /* DataCache.swift in Sources */,
+				02E58FA42535C9E30039F3A5 /* RelationshipData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ContentfulPersistenceSwift.podspec
+++ b/ContentfulPersistenceSwift.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '2.0'
   spec.tvos.deployment_target    = '9.3'
 
-  spec.dependency 'Contentful', '~> 5.2.0'
+  spec.dependency 'Contentful', '~> 5.3.0'
 end
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
             targets: ["ContentfulPersistence"])
     ],
     dependencies: [
-        .package(url: "https://github.com/contentful/contentful.swift", .upToNextMajor(from: "5.2.0"))
+        .package(url: "https://github.com/contentful/contentful.swift", .upToNextMajor(from: "5.3.0"))
     ],
     targets: [
         .target(

--- a/Sources/ContentfulPersistence/Relationships/RelationshipData.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipData.swift
@@ -1,0 +1,181 @@
+//
+//  ContentfulPersistence
+//
+
+import Foundation
+
+struct RelationshipData: Codable {
+
+    typealias ParentId = String
+    typealias ChildId = String
+    struct FieldLocaleKey: Codable, Hashable {
+        let parentId: ParentId
+        let field: String
+        let locale: String?
+    }
+
+    // quick access to all child ids by parent and relation type
+    private var childIdsByParent = [ParentId: Set<ChildId>]()
+    // quick access to all field/locale relationships by child id
+    private(set) internal var toOneRelationShiptsByEntryId = [ChildId: [FieldLocaleKey: ToOneRelationship]]()
+    private(set) internal var toManyRelationShipsbyEntryId = [ChildId: [FieldLocaleKey: ToManyRelationship.Id]]()
+    private var toManyRelationShips = [ToManyRelationship.Id: ToManyRelationship]()
+
+    var isEmpty: Bool {
+        toOneRelationShiptsByEntryId.isEmpty && toManyRelationShipsbyEntryId.isEmpty
+    }
+
+    var count: Int {
+        let numberOfToOneRelationships = toOneRelationShiptsByEntryId.values.map { $0.count }.reduce(0, +)
+        return numberOfToOneRelationships + toManyRelationShips.count
+    }
+
+    static let empty: RelationshipData = .init(
+        childIdsByParent: [:],
+        toOneRelationShiptsByEntryId: [:],
+        toManyRelationShipsbyEntryId: [:],
+        toManyRelationShips: [:]
+    )
+
+    mutating func append(_ relationship: Relationship) {
+        switch relationship {
+        case .toMany(let nested):
+            let fieldKey = FieldLocaleKey(parentId: nested.parentId, field: nested.fieldName, locale: nested.childIds.first?.localeCode)
+            let childIds = Set(nested.childIds.map { $0.id })
+            // append quick access cache
+            childIdsByParent[nested.parentId] = (childIdsByParent[nested.parentId] ?? Set()).union(nested.childIds.map { $0.id })
+
+            let relationShipId = nested.id
+            toManyRelationShips[relationShipId] = nested
+
+            for childId in childIds {
+                var relationsByFieldAndLocale = toManyRelationShipsbyEntryId[childId] ?? [:]
+                relationsByFieldAndLocale[fieldKey] = relationShipId
+                toManyRelationShipsbyEntryId[childId] = relationsByFieldAndLocale
+            }
+
+        case .toOne(let nested):
+            let fieldKey = FieldLocaleKey(parentId: nested.parentId, field: nested.fieldName, locale: nested.childId.localeCode)
+            // append quick access cache
+            childIdsByParent[nested.parentId] = (childIdsByParent[nested.parentId] ?? Set()).union([nested.childId.id])
+
+            var relationsByFieldAndLocale = toOneRelationShiptsByEntryId[nested.childId.id] ?? [:]
+            relationsByFieldAndLocale[fieldKey] = nested
+            toOneRelationShiptsByEntryId[nested.childId.id] = relationsByFieldAndLocale
+        }
+    }
+
+    mutating func delete(parentId: String) {
+        guard var childIdsByParent = childIdsByParent[parentId] else { return }
+
+        for childId in childIdsByParent {
+
+            var emptyToOne = false
+            var emptyToMany = false
+
+            if var toOne = toOneRelationShiptsByEntryId[childId] {
+                let keyForParent = toOne.keys.filter { $0.parentId == parentId }
+                keyForParent.forEach { toOne[$0] = nil }
+                emptyToOne = toOne.isEmpty
+                toOneRelationShiptsByEntryId[childId] = emptyToOne ? nil : toOne
+            } else {
+                emptyToOne = true
+            }
+
+            if var toMany = toManyRelationShipsbyEntryId[childId] {
+                let keyForParent = toMany.keys.filter { $0.parentId == parentId }
+                keyForParent.forEach { toMany[$0] = nil }
+                emptyToMany = toMany.isEmpty
+                toManyRelationShipsbyEntryId[childId] = emptyToMany ? nil : toMany
+            } else {
+                emptyToMany = true
+            }
+
+            // remove unused parent
+            if emptyToOne && emptyToMany {
+                childIdsByParent.remove(childId)
+            }
+        }
+        self.childIdsByParent[parentId] = childIdsByParent.isEmpty ? nil : childIdsByParent
+
+        cleanup()
+    }
+
+    mutating func delete(parentId: ParentId, fieldName: String, localeCode: String?) {
+
+        guard var childIdsByParent = childIdsByParent[parentId] else { return }
+
+        let fieldKey = FieldLocaleKey(parentId: parentId, field: fieldName, locale: localeCode)
+
+        for childId in childIdsByParent {
+            var emptyToOne = false
+            var emptyToMany = false
+
+            if var toOne = toOneRelationShiptsByEntryId[childId] {
+                toOne[fieldKey] = nil
+                emptyToOne = toOne.isEmpty
+                toOneRelationShiptsByEntryId[childId] = emptyToOne ? nil : toOne
+            } else {
+                emptyToOne = true
+            }
+
+            if var toMany = toManyRelationShipsbyEntryId[childId] {
+                toMany[fieldKey] = nil
+                emptyToMany = toMany.isEmpty
+                toManyRelationShipsbyEntryId[childId] = emptyToMany ? nil : toMany
+            } else {
+                emptyToMany = true
+            }
+
+            // remove unused parent
+            if emptyToOne && emptyToMany {
+                childIdsByParent.remove(childId)
+            }
+        }
+
+        self.childIdsByParent[parentId] = childIdsByParent.isEmpty ? nil : childIdsByParent
+
+        cleanup()
+    }
+
+    func findToOne(childId: ChildId, localeCode: String?) -> [ToOneRelationship] {
+        guard let relations = toOneRelationShiptsByEntryId[childId] else { return [] }
+
+        return relations.keys
+            .filter { $0.locale == localeCode }
+            .compactMap { relations[$0] }
+    }
+
+    func findToMany(childId: ChildId, localeCode: String?) -> [ToManyRelationship] {
+        guard let relations = toManyRelationShipsbyEntryId[childId] else { return [] }
+
+        return relations.keys
+            .filter { $0.locale == localeCode }
+            .compactMap { relations[$0] }
+            .compactMap { toManyRelationShips[$0] }
+    }
+
+    private mutating func cleanup() {
+        // remove unused to many references
+        let stored = Set(toManyRelationShips.keys)
+        let used = Set(toManyRelationShipsbyEntryId.map { $0.value.map { $0.value } }.flatMap { $0 })
+
+        stored.subtracting(used).forEach {
+            toManyRelationShips[$0] = nil
+        }
+    }
+}
+
+extension ToManyRelationship: Identifiable {
+    typealias Id = String
+    var id: Id {
+        ([parentType, parentId, fieldName, childIds.first?.localeCode ?? "-"] + childIds.map { $0.id }.sorted()).joined(separator: ",")
+    }
+}
+
+extension ToOneRelationship: Identifiable {
+    typealias Id = String
+    var id: Id {
+        [parentType, parentId, fieldName, childId.id, childId.localeCode ?? "-"].joined(separator: ",")
+    }
+}

--- a/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
+++ b/Sources/ContentfulPersistence/Relationships/RelationshipsManager.swift
@@ -10,8 +10,8 @@ final class RelationshipsManager {
 
     private let cache: RelationshipCache
 
-    var relationships: [Relationship] {
-        return cache.relationships
+    var relationships: RelationshipData {
+        cache.relationships
     }
 
     init(cacheFileName: String) {
@@ -24,8 +24,6 @@ final class RelationshipsManager {
         childId: String,
         fieldName: String
     ) {
-        let theChildId = RelationshipChildId(value: childId)
-        delete(parentId: parent.id, fieldName: fieldName, localeCode: theChildId.localeCode)
 
         let parentType = type(of: parent).contentTypeId
 
@@ -45,8 +43,6 @@ final class RelationshipsManager {
         fieldName: String
     ) {
         let theChildIds: [RelationshipChildId] = childIds.map { .init(value: $0) }
-        delete(parentId: parent.id, fieldName: fieldName, localeCode: theChildIds.first?.localeCode)
-
         let parentType = type(of: parent).contentTypeId
 
         let relationship = ToManyRelationship(

--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -592,7 +592,7 @@ public class SynchronizationManager: PersistenceIntegration {
             var fieldValue = entry.fields[fieldName]
 
             // handle symbol arrays
-            if let array = fieldValue as? [NSCoding] {
+            if let array = fieldValue as? [Any] {
                 fieldValue = NSKeyedArchiver.archivedData(withRootObject: array)
             }
             if persistable.entity.attributesByName[fieldName]?.attributeType == .dateAttributeType, let date = getDate(fieldValue as? String) {

--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -592,7 +592,7 @@ public class SynchronizationManager: PersistenceIntegration {
             var fieldValue = entry.fields[fieldName]
 
             // handle symbol arrays
-            if let array = fieldValue as? [Any] {
+            if let array = fieldValue as? [NSCoding] {
                 fieldValue = NSKeyedArchiver.archivedData(withRootObject: array)
             }
             if persistable.entity.attributesByName[fieldName]?.attributeType == .dateAttributeType, let date = getDate(fieldValue as? String) {

--- a/Sources/ContentfulPersistence/SynchronizationManager.swift
+++ b/Sources/ContentfulPersistence/SynchronizationManager.swift
@@ -265,9 +265,10 @@ public class SynchronizationManager: PersistenceIntegration {
     }
 
     private func updateToOneRelationships(with entry: EntryPersistable) {
-        let filteredRelationships: [ToOneRelationship] = relationshipsManager.relationships
-            .compactMap { $0.value() }
-            .filter { $0.childId.id == entry.id && $0.childId.localeCode == entry.localeCode }
+        let filteredRelationships: [ToOneRelationship] = relationshipsManager.relationships.findToOne(
+            childId: entry.id,
+            localeCode: entry.localeCode
+        )
 
         for relationship in filteredRelationships {
             if let parentType = persistenceModel.entryTypes.first(where: { $0.contentTypeId == relationship.parentType }) {
@@ -285,9 +286,10 @@ public class SynchronizationManager: PersistenceIntegration {
     }
 
     private func updateToManyRelationships(with entry: EntryPersistable) {
-        let filteredRelationships: [ToManyRelationship] = relationshipsManager.relationships
-            .compactMap { $0.value() }
-            .filter { $0.childIds.map({ $0.id }).contains(entry.id) && $0.childIds.first?.localeCode == entry.localeCode }
+        let filteredRelationships: [ToManyRelationship] = relationshipsManager.relationships.findToMany(
+            childId: entry.id,
+            localeCode: entry.localeCode
+        )
 
         for relationship in filteredRelationships {
             if let parentType = persistenceModel.entryTypes.first(where: { $0.contentTypeId == relationship.parentType }) {


### PR DESCRIPTION
This pull request refactors the relation ship caching component to speed up parsing of very big models with a lot of data and many relations. A full sync of our spaces took about 30 minutes. This pull request brings this down to ~30sec. 

Most time was spend filtering the growing flat list of relations. The new implementation is a more complex but the approach tries to have every necessary relation at hand in dictionaries mapping ids/combined keys to relation references.